### PR TITLE
Add addShift functionality

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -193,14 +193,14 @@ Format: `exit`
 
 ## Basic Management of Staff Schedules
 
-### Adding a staff's schedule: `addSchedule`
+### Adding a shift to staff's schedule: `addShift`
 
 Adds a time period where the staff is working to the staff’s schedule.
 
 Formats:
 
-`addSchedule n/name d/fullDayName-shiftNumber` \
-`addSchedule i/index d/fullDayName-shiftNumber`
+`addShift n/name d/fullDayName-shiftNumber` \
+`addShift i/index d/fullDayName-shiftNumber`
 
 
 * There are two ways to identify the staff to add the time period to: by their `name` or by their staff `index`.
@@ -208,8 +208,8 @@ Formats:
 
 Examples:
 
-`addSchedule n/Candice d/Monday-1` \
-`addSchedule i/1234 d/tuesday-2`
+`addShift n/Candice d/Monday-1` \
+`addShift i/1234 d/tuesday-0`
 
 ### View a staff schedule : `viewSchedule`
 

--- a/src/main/java/seedu/address/logic/commands/AddShiftCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddShiftCommand.java
@@ -1,0 +1,88 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.time.DayOfWeek;
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Slot;
+import seedu.address.model.person.exceptions.DuplicateShiftException;
+
+/**
+ * Adds a shift to a staff's schedule.
+ */
+public class AddShiftCommand extends Command {
+    public static final String COMMAND_WORD = "addShift";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a shift to target person ";
+
+    public static final String MESSAGE_ADD_SHIFT_SUCCESS = "New shift added to the schedule of %1$s: %1$s, %1$s";
+    public static final String MESSAGE_PERSON_NOT_EXIST = "This staff does not exist in the address book";
+    public static final String MESSAGE_DUPLICATE_SHIFT = "This shift already exists in the staff's schedule";
+
+    private final Index index;
+    private final DayOfWeek dayOfWeek;
+    private final Slot slot;
+
+    /**
+     * Creates an AddShiftCommand to add the specified {@code Shift} to a {@code Person}.
+     */
+    public AddShiftCommand(Index index, DayOfWeek dayOfWeek, Slot slot) {
+        requireAllNonNull(index, dayOfWeek, slot);
+        this.index = index;
+        this.dayOfWeek = dayOfWeek;
+        this.slot = slot;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person staffToEdit = lastShownList.get(index.getZeroBased());
+
+        if (!model.hasPerson(staffToEdit)) {
+            throw new CommandException(MESSAGE_PERSON_NOT_EXIST);
+        }
+
+        try {
+            model.addShift(staffToEdit, dayOfWeek, slot);
+        } catch (DuplicateShiftException de) {
+            throw new CommandException(MESSAGE_DUPLICATE_SHIFT);
+        }
+
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(String.format(MESSAGE_ADD_SHIFT_SUCCESS, staffToEdit, dayOfWeek, slot));
+
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddShiftCommand)) {
+            return false;
+        }
+
+        // state check
+        AddShiftCommand command = (AddShiftCommand) other;
+        return index.equals(command.index)
+                && dayOfWeek.equals(command.dayOfWeek)
+                && slot.equals(command.slot);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/AddShiftCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddShiftCommand.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DAY_SHIFT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.time.DayOfWeek;
@@ -11,6 +13,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Slot;
 import seedu.address.model.person.exceptions.DuplicateShiftException;
@@ -21,24 +24,39 @@ import seedu.address.model.person.exceptions.DuplicateShiftException;
 public class AddShiftCommand extends Command {
     public static final String COMMAND_WORD = "addShift";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a shift to target person ";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": adds a shift to the staff identified "
+            + "by\nthe index number used in the displayed staff list or\nthe name of staff." + "\n"
+            + "Parameters: "
+            + "[" + PREFIX_INDEX + "INDEX] or "
+            + "[" + PREFIX_NAME + "NAME] + "
+            + "[" + PREFIX_DAY_SHIFT + "DAY AND\nSLOT OF A SHIFT]" + "\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_INDEX + "1 "
+            + PREFIX_DAY_SHIFT + "monday-1" + "\n"
+            + "OR: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "JOE "
+            + PREFIX_DAY_SHIFT + "TUESDAY-0";
 
-    public static final String MESSAGE_ADD_SHIFT_SUCCESS = "New shift added to the schedule of %1$s: %1$s, %1$s";
-    public static final String MESSAGE_PERSON_NOT_EXIST = "This staff does not exist in the address book";
-    public static final String MESSAGE_DUPLICATE_SHIFT = "This shift already exists in the staff's schedule";
+
+    public static final String MESSAGE_ADD_SHIFT_SUCCESS = "New shift added to the schedule of %s: %s, %s.";
+    public static final String MESSAGE_PERSON_NOT_EXIST = "This staff does not exist in the address book.";
+    public static final String MESSAGE_DUPLICATE_SHIFT = "This shift already exists in the staff's schedule.";
 
     private final Index index;
+    private final Name name;
     private final DayOfWeek dayOfWeek;
     private final Slot slot;
 
     /**
      * Creates an AddShiftCommand to add the specified {@code Shift} to a {@code Person}.
      */
-    public AddShiftCommand(Index index, DayOfWeek dayOfWeek, Slot slot) {
-        requireAllNonNull(index, dayOfWeek, slot);
+    public AddShiftCommand(Index index, Name name, String shiftDateAndSlot) {
+        requireNonNull(shiftDateAndSlot);
         this.index = index;
-        this.dayOfWeek = dayOfWeek;
-        this.slot = slot;
+        this.name = name;
+        String[] strings = shiftDateAndSlot.split("-");
+        dayOfWeek = DayOfWeek.valueOf(strings[0].toUpperCase());
+        slot = Slot.getSlotByOrder(strings[1]);
     }
 
     @Override
@@ -46,13 +64,22 @@ public class AddShiftCommand extends Command {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
 
-        if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        Person staffToEdit;
+
+        if (index != null) {
+            if (index.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
+            staffToEdit = lastShownList.get(index.getZeroBased());
+        } else {
+            if (name != null) {
+                staffToEdit = model.findPersonByName(name);
+            } else {
+                throw new CommandException(MESSAGE_USAGE);
+            }
         }
 
-        Person staffToEdit = lastShownList.get(index.getZeroBased());
-
-        if (!model.hasPerson(staffToEdit)) {
+        if (staffToEdit == null || !model.hasPerson(staffToEdit)) {
             throw new CommandException(MESSAGE_PERSON_NOT_EXIST);
         }
 
@@ -63,7 +90,7 @@ public class AddShiftCommand extends Command {
         }
 
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_ADD_SHIFT_SUCCESS, staffToEdit, dayOfWeek, slot));
+        return new CommandResult(String.format(MESSAGE_ADD_SHIFT_SUCCESS, staffToEdit.getName(), dayOfWeek, slot));
 
     }
 
@@ -81,7 +108,8 @@ public class AddShiftCommand extends Command {
 
         // state check
         AddShiftCommand command = (AddShiftCommand) other;
-        return index.equals(command.index)
+        return ((index == null && command.index == null) || (index != null && index.equals(command.index)))
+                && ((name == null && command.name == null) || (name != null && name.equals(command.name)))
                 && dayOfWeek.equals(command.dayOfWeek)
                 && slot.equals(command.slot);
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -63,7 +63,7 @@ public class EditCommand extends Command {
     private final EditPersonDescriptor editStaffDescriptor;
 
     /**
-     * @param index                of the person in the filtered person list to edit
+     * @param index of the person in the filtered person list to edit
      * @param editStaffDescriptor details to edit the person with
      */
     public EditCommand(Index index, EditPersonDescriptor editStaffDescriptor) {

--- a/src/main/java/seedu/address/logic/parser/AddShiftCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddShiftCommandParser.java
@@ -3,16 +3,16 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DAY_SHIFT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_SLOT_SHIFT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE_SHIFT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
-import java.time.DayOfWeek;
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddShiftCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Slot;
+import seedu.address.model.person.Name;
+
 
 public class AddShiftCommandParser implements Parser<AddShiftCommand> {
 
@@ -25,23 +25,33 @@ public class AddShiftCommandParser implements Parser<AddShiftCommand> {
     public AddShiftCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_DAY_SHIFT, PREFIX_TYPE_SHIFT, PREFIX_SLOT_SHIFT);
+                ArgumentTokenizer.tokenize(args, PREFIX_INDEX, PREFIX_DAY_SHIFT, PREFIX_NAME);
 
-        Index index;
-        DayOfWeek dayOfWeek = ParserUtil.parseDayOfWeek(argMultimap.getValue(PREFIX_DAY_SHIFT).get());
-        Slot slot = ParserUtil.parseSlot(argMultimap.getValue(PREFIX_SLOT_SHIFT).get());
+        Index index = null;
+        Name name = null;
+        String shiftDayAndSlot;
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_DAY_SHIFT, PREFIX_SLOT_SHIFT)
-                || argMultimap.getPreamble().isEmpty()) {
+        //PREFIX_DAY_SHIFT must exist and exactly one from PREFIX_INDEX and PREFIX_NAME must exist.
+        if (!arePrefixesPresent(argMultimap, PREFIX_DAY_SHIFT)
+                || !argMultimap.getPreamble().isEmpty() || (!arePrefixesPresent(argMultimap, PREFIX_INDEX)
+                && !arePrefixesPresent(argMultimap, PREFIX_NAME))
+                || (arePrefixesPresent(argMultimap, PREFIX_INDEX)
+                        && arePrefixesPresent(argMultimap, PREFIX_NAME))) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddShiftCommand.MESSAGE_USAGE));
         }
 
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            if (argMultimap.getValue(PREFIX_INDEX).isPresent()) {
+                index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get());
+            }
+            if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+                name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+            }
+            shiftDayAndSlot = ParserUtil.parseDayOfWeek(argMultimap.getValue(PREFIX_DAY_SHIFT).get());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddShiftCommand.MESSAGE_USAGE), pe);
         }
-        return new AddShiftCommand(index, dayOfWeek, slot);
+        return new AddShiftCommand(index, name, shiftDayAndSlot);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/AddShiftCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddShiftCommandParser.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DAY_SHIFT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SLOT_SHIFT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE_SHIFT;
+
+import java.time.DayOfWeek;
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddShiftCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Slot;
+
+public class AddShiftCommandParser implements Parser<AddShiftCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddShiftCommand
+     * and returns an AddShiftCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format.
+     */
+    public AddShiftCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_DAY_SHIFT, PREFIX_TYPE_SHIFT, PREFIX_SLOT_SHIFT);
+
+        Index index;
+        DayOfWeek dayOfWeek = ParserUtil.parseDayOfWeek(argMultimap.getValue(PREFIX_DAY_SHIFT).get());
+        Slot slot = ParserUtil.parseSlot(argMultimap.getValue(PREFIX_SLOT_SHIFT).get());
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_DAY_SHIFT, PREFIX_SLOT_SHIFT)
+                || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddShiftCommand.MESSAGE_USAGE));
+        }
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddShiftCommand.MESSAGE_USAGE), pe);
+        }
+        return new AddShiftCommand(index, dayOfWeek, slot);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddShiftCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -62,6 +63,9 @@ public class AddressBookParser {
 
         case ViewCommand.COMMAND_WORD:
             return new ViewCommandParser().parse(arguments);
+
+        case AddShiftCommand.COMMAND_WORD:
+            return new AddShiftCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -16,7 +16,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_DAY_SHIFT = new Prefix("d/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_INDEX = new Prefix("i/");
-    public static final Prefix PREFIX_SLOT_SHIFT = new Prefix("sl/");
-    public static final Prefix PREFIX_TYPE_SHIFT = new Prefix("ty/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -16,5 +16,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_DAY_SHIFT = new Prefix("d/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_INDEX = new Prefix("i/");
+    public static final Prefix PREFIX_SLOT_SHIFT = new Prefix("sl/");
+    public static final Prefix PREFIX_TYPE_SHIFT = new Prefix("ty/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.DayOfWeek;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -16,6 +17,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Role;
 import seedu.address.model.person.Salary;
+import seedu.address.model.person.Slot;
 import seedu.address.model.person.Status;
 import seedu.address.model.tag.Tag;
 
@@ -151,6 +153,46 @@ public class ParserUtil {
             throw new ParseException(Status.MESSAGE_CONSTRAINTS);
         }
         return Status.translateStringToStatus(trimmedStatus);
+    }
+
+    /**
+     * Parses a {@code String dayOfWeek} into an {@code DayOfWeek}.
+     * Leading and trailing whitespaces will be trimmed.
+     * This parser is not case sensitive.
+     *
+     * @throws ParseException if the given {@code dayOfWeek} is invalid.
+     */
+    public static DayOfWeek parseDayOfWeek(String dayOfWeek) throws ParseException {
+        String MESSAGE_CONSTRAINTS = "List of valid dayOfWeek: " +
+                "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday.";;
+        requireNonNull(dayOfWeek);
+        String trimmedDayOfWeek = dayOfWeek.trim().toLowerCase();
+        switch (trimmedDayOfWeek) {
+        case "monday": return DayOfWeek.MONDAY;
+        case "tuesday": return DayOfWeek.TUESDAY;
+        case "wednesday": return DayOfWeek.WEDNESDAY;
+        case "thursday": return DayOfWeek.THURSDAY;
+        case "friday": return DayOfWeek.FRIDAY;
+        case "saturday": return DayOfWeek.SATURDAY;
+        case "sunday": return DayOfWeek.SUNDAY;
+        default: throw new ParseException(MESSAGE_CONSTRAINTS);
+        }
+    }
+
+    /**
+     * Parses a {@code String dayOfWeek} into an {@code DayOfWeek}.
+     * Leading and trailing whitespaces will be trimmed.
+     * This parser is not case sensitive.
+     *
+     * @throws ParseException if the given {@code dayOfWeek} is invalid.
+     */
+    public static Slot parseSlot(String slot) throws ParseException {
+        requireNonNull(slot);
+        String trimmedSlot = slot.trim();
+        if (!Slot.isValidSlot(trimmedSlot)) {
+            throw new ParseException(Slot.MESSAGE_CONSTRAINTS);
+        }
+        return Slot.translateStringToSlot(slot);    //maybe need to assert slot cannot be null
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
-import java.time.DayOfWeek;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -162,21 +161,31 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code dayOfWeek} is invalid.
      */
-    public static DayOfWeek parseDayOfWeek(String dayOfWeek) throws ParseException {
-        String messageConstraints = "List of valid dayOfWeek: "
-                + "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday.";;
-        requireNonNull(dayOfWeek);
-        String trimmedDayOfWeek = dayOfWeek.trim().toLowerCase();
-        switch (trimmedDayOfWeek) {
-        case "monday": return DayOfWeek.MONDAY;
-        case "tuesday": return DayOfWeek.TUESDAY;
-        case "wednesday": return DayOfWeek.WEDNESDAY;
-        case "thursday": return DayOfWeek.THURSDAY;
-        case "friday": return DayOfWeek.FRIDAY;
-        case "saturday": return DayOfWeek.SATURDAY;
-        case "sunday": return DayOfWeek.SUNDAY;
+    public static String parseDayOfWeek(String shiftDay) throws ParseException {
+        String messageConstraints = "Valid input format: dayOfWeek + slotNumber:" + "List of valid dayOfWeek: "
+                + "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday. (Not case-sensitive)\n"
+                + "List of valid slotNumber: 1, 2.";
+        requireNonNull(shiftDay);
+        String trimmedStr = shiftDay.trim().toLowerCase();
+        String[] strings = trimmedStr.split("-");
+        switch (strings[0]) {
+        case "monday":
+        case "tuesday":
+        case "wednesday":
+        case "thursday":
+        case "friday":
+        case "saturday":
+        case "sunday":
+            break;
         default: throw new ParseException(messageConstraints);
         }
+        switch (strings[1]) {
+        case "0":
+        case "1":
+            break;
+        default: throw new ParseException(messageConstraints);
+        }
+        return trimmedStr;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -163,8 +163,8 @@ public class ParserUtil {
      * @throws ParseException if the given {@code dayOfWeek} is invalid.
      */
     public static DayOfWeek parseDayOfWeek(String dayOfWeek) throws ParseException {
-        String MESSAGE_CONSTRAINTS = "List of valid dayOfWeek: " +
-                "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday.";;
+        String messageConstraints = "List of valid dayOfWeek: "
+                + "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday.";;
         requireNonNull(dayOfWeek);
         String trimmedDayOfWeek = dayOfWeek.trim().toLowerCase();
         switch (trimmedDayOfWeek) {
@@ -175,7 +175,7 @@ public class ParserUtil {
         case "friday": return DayOfWeek.FRIDAY;
         case "saturday": return DayOfWeek.SATURDAY;
         case "sunday": return DayOfWeek.SUNDAY;
-        default: throw new ParseException(MESSAGE_CONSTRAINTS);
+        default: throw new ParseException(messageConstraints);
         }
     }
 
@@ -192,7 +192,8 @@ public class ParserUtil {
         if (!Slot.isValidSlot(trimmedSlot)) {
             throw new ParseException(Slot.MESSAGE_CONSTRAINTS);
         }
-        return Slot.translateStringToSlot(slot);    //maybe need to assert slot cannot be null
+        //maybe need to assert slot cannot be null
+        return Slot.translateStringToSlot(slot);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Slot;
 import seedu.address.model.person.exceptions.DuplicateShiftException;
@@ -78,6 +79,13 @@ public interface Model {
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
      */
     void setPerson(Person target, Person editedStaff);
+
+    /**
+     * Returns the person with given name.
+     * @param name Given name.
+     * @return Matched Person.
+     */
+    Person findPersonByName(Name name);
 
     /**
      * Add a shift to a target staff's schedule.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,11 +1,14 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.time.DayOfWeek;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Slot;
+import seedu.address.model.person.exceptions.DuplicateShiftException;
 
 /**
  * The API of the Model component.
@@ -75,6 +78,17 @@ public interface Model {
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
      */
     void setPerson(Person target, Person editedStaff);
+
+    /**
+     * Add a shift to a target staff's schedule.
+     * {@code target} must exist in the address book.
+     *
+     * @param target The target staff.
+     * @param dayOfWeek of the shift.
+     * @param slot of the shift.
+     * @throws DuplicateShiftException Throws when there is already a shift at the target slot.
+     */
+    void addShift(Person target, DayOfWeek dayOfWeek, Slot slot) throws DuplicateShiftException;
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -5,13 +5,16 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
 import java.time.DayOfWeek;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Slot;
 import seedu.address.model.person.exceptions.DuplicateShiftException;
@@ -115,6 +118,16 @@ public class ModelManager implements Model {
         addressBook.setPerson(target, editedStaff);
     }
 
+    @Override
+    public Person findPersonByName(Name name) {
+        List<Person> results = filteredPersons.stream().filter(person -> person.getName().equals(name))
+                .collect(Collectors.toList());
+        if (results.size() == 0) {
+            return null;
+        }
+        return results.get(0);
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**
@@ -135,7 +148,7 @@ public class ModelManager implements Model {
     @Override
     public void addShift(Person target, DayOfWeek dayOfWeek, Slot slot) throws DuplicateShiftException {
         requireAllNonNull(target, dayOfWeek, slot);
-        target.setSchedule(dayOfWeek, slot);
+        target.changeSchedule(dayOfWeek, slot);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.time.DayOfWeek;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -12,6 +13,8 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Slot;
+import seedu.address.model.person.exceptions.DuplicateShiftException;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -127,6 +130,12 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    @Override
+    public void addShift(Person target, DayOfWeek dayOfWeek, Slot slot) throws DuplicateShiftException {
+        requireAllNonNull(target, dayOfWeek, slot);
+        target.setSchedule(dayOfWeek, slot);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,12 +2,14 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.DayOfWeek;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import seedu.address.model.person.exceptions.DuplicateShiftException;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -94,6 +96,17 @@ public class Person {
      */
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
+    }
+
+    /**
+     * Add a shift to the staff's schedule.
+     *
+     * @param dayOfWeek The day of the shift.
+     * @param slot The time slot of the shift.
+     * @throws DuplicateShiftException throws when there is already a shift in the target slot.
+     */
+    public void setSchedule(DayOfWeek dayOfWeek, Slot slot) throws DuplicateShiftException {
+        schedule.addShift(dayOfWeek, slot);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -29,8 +29,9 @@ public class Person {
     private final Salary salary;
     private final Status status;
     private final Set<Tag> tags = new HashSet<>();
-    private final Schedule schedule;
     private final Set<Field> fields = new HashSet<>();
+
+    private Schedule schedule;
 
     /**
      * Every field must be present and not null.
@@ -105,8 +106,12 @@ public class Person {
      * @param slot The time slot of the shift.
      * @throws DuplicateShiftException throws when there is already a shift in the target slot.
      */
-    public void setSchedule(DayOfWeek dayOfWeek, Slot slot) throws DuplicateShiftException {
+    public void changeSchedule(DayOfWeek dayOfWeek, Slot slot) throws DuplicateShiftException {
         schedule.addShift(dayOfWeek, slot);
+    }
+
+    public void setSchedule(Schedule schedule) {
+        this.schedule = schedule;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Schedule.java
+++ b/src/main/java/seedu/address/model/person/Schedule.java
@@ -15,7 +15,7 @@ public class Schedule {
     private static final int DAY_OF_WEEK = 7;
     private static final int PERIOD_OF_DAY = 2;
 
-    private Shift[][] shifts;
+    private Shift[][] shifts = new Shift[7][2];
 
     /**
      * Initialize schedule object.
@@ -37,30 +37,8 @@ public class Schedule {
             String[] shiftString = s.split("-");
             DayOfWeek shiftDay = DayOfWeek.valueOf(shiftString[0]);
             Slot shiftSlot = Slot.translateStringToSlot(shiftString[1]);
-            if (shiftString.length == 2) {
-                shifts[shiftDay.getValue()][shiftSlot.getOrder()] = new Shift(shiftDay, shiftSlot);
-            } else {
-                String shiftName = shiftString[2];
-                shifts[shiftDay.getValue()][shiftSlot.getOrder()] = new Shift(shiftDay, shiftSlot, shiftName);
-            }
-
+            shifts[shiftDay.getValue()][shiftSlot.getOrder()] = new Shift(shiftDay, shiftSlot);
         }
-    }
-
-    /**
-     * Adds a new shift for a staff.
-     *
-     * @param dayOfWeek The day of the shift in a week.
-     * @param slot The slot of the shift located.
-     * @param shiftName The name of the shift.
-     * @throws DuplicateShiftException throws when there is already a shift in the target slot.
-     */
-    public void addShift(DayOfWeek dayOfWeek, Slot slot, String shiftName) throws DuplicateShiftException {
-        Shift shift = new Shift(dayOfWeek, slot, shiftName);
-        if (shifts[dayOfWeek.getValue() - 1][slot.getOrder()] != null) {
-            throw new DuplicateShiftException();
-        }
-        shifts[dayOfWeek.getValue() - 1][slot.getOrder()] = shift;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Schedule.java
+++ b/src/main/java/seedu/address/model/person/Schedule.java
@@ -37,7 +37,7 @@ public class Schedule {
             String[] shiftString = s.split("-");
             DayOfWeek shiftDay = DayOfWeek.valueOf(shiftString[0]);
             Slot shiftSlot = Slot.translateStringToSlot(shiftString[1]);
-            shifts[shiftDay.getValue()][shiftSlot.getOrder()] = new Shift(shiftDay, shiftSlot);
+            shifts[shiftDay.getValue() - 1][shiftSlot.getOrder()] = new Shift(shiftDay, shiftSlot);
         }
     }
 

--- a/src/main/java/seedu/address/model/person/Schedule.java
+++ b/src/main/java/seedu/address/model/person/Schedule.java
@@ -3,6 +3,8 @@ package seedu.address.model.person;
 import java.time.DayOfWeek;
 import java.util.Objects;
 
+import seedu.address.model.person.exceptions.DuplicateShiftException;
+
 /**
  * Represents the schedule for the staff, which contains all the task for the staff.
  */
@@ -51,9 +53,28 @@ public class Schedule {
      * @param dayOfWeek The day of the shift in a week.
      * @param slot The slot of the shift located.
      * @param shiftName The name of the shift.
+     * @throws DuplicateShiftException throws when there is already a shift in the target slot.
      */
-    public void addShift(DayOfWeek dayOfWeek, Slot slot, String shiftName) {
+    public void addShift(DayOfWeek dayOfWeek, Slot slot, String shiftName) throws DuplicateShiftException {
         Shift shift = new Shift(dayOfWeek, slot, shiftName);
+        if (shifts[dayOfWeek.getValue() - 1][slot.getOrder()] != null) {
+            throw new DuplicateShiftException();
+        }
+        shifts[dayOfWeek.getValue() - 1][slot.getOrder()] = shift;
+    }
+
+    /**
+     * Adds a new shift for a staff.
+     *
+     * @param dayOfWeek The day of the shift in a week.
+     * @param slot The slot of the shift located.
+     * @throws DuplicateShiftException throws when there is already a shift in the target slot.
+     */
+    public void addShift(DayOfWeek dayOfWeek, Slot slot) throws DuplicateShiftException {
+        Shift shift = new Shift(dayOfWeek, slot);
+        if (shifts[dayOfWeek.getValue() - 1][slot.getOrder()] != null) {
+            throw new DuplicateShiftException();
+        }
         shifts[dayOfWeek.getValue() - 1][slot.getOrder()] = shift;
     }
 

--- a/src/main/java/seedu/address/model/person/Shift.java
+++ b/src/main/java/seedu/address/model/person/Shift.java
@@ -48,7 +48,7 @@ public class Shift {
      * Returns a String representation of the shift that is suitable for json.
      */
     public String toSaveString() {
-        return dayOfWeek.toString() + "-" + slot.getValue();
+        return dayOfWeek.toString() + "-" + slot.getValue() + " ";
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Shift.java
+++ b/src/main/java/seedu/address/model/person/Shift.java
@@ -1,28 +1,13 @@
 package seedu.address.model.person;
 
 import java.time.DayOfWeek;
-import java.util.Objects;
 
 /**
  * Represents a piece of work for a staff.
  */
 public class Shift {
-    private String shiftName;
     private Slot slot;
     private DayOfWeek dayOfWeek;
-
-    /**
-     * Constructor of Shift given its weekday, time, and name.
-     *
-     * @param dayOfWeek Weekday of the shift.
-     * @param slot The slot when the task located.
-     * @param shiftName Name of the task.
-     */
-    public Shift(DayOfWeek dayOfWeek, Slot slot, String shiftName) {
-        this.dayOfWeek = dayOfWeek;
-        this.slot = slot;
-        this.shiftName = shiftName;
-    }
 
     /**
      * Constructor of Task given its weekday, time, and name.
@@ -33,15 +18,6 @@ public class Shift {
     public Shift(DayOfWeek dayOfWeek, Slot slot) {
         this.dayOfWeek = dayOfWeek;
         this.slot = slot;
-    }
-
-
-    /**
-     * Sets name of the shift.
-     * @param shiftName Name of the shift.
-     */
-    public void setShiftName(String shiftName) {
-        this.shiftName = shiftName;
     }
 
     /**
@@ -65,18 +41,14 @@ public class Shift {
 
     @Override
     public String toString() {
-        return shiftName + ": in " + dayOfWeek.toString() + " " + slot.getValue();
+        return dayOfWeek.toString() + "-" + slot.getValue();
     }
 
     /**
      * Returns a String representation of the shift that is suitable for json.
      */
     public String toSaveString() {
-        String add = shiftName;
-        if (Objects.isNull(shiftName)) {
-            add = "";
-        }
-        return dayOfWeek.toString() + "-" + slot.getValue() + "-" + add;
+        return dayOfWeek.toString() + "-" + slot.getValue();
     }
 
     /**
@@ -100,7 +72,7 @@ public class Shift {
             return false;
         }
         String[] stringSplit = test.split("-");
-        if (2 == stringSplit.length || stringSplit.length == 3) {
+        if (stringSplit.length == 2) {
             String dayString = stringSplit[0];
             String slotString = stringSplit[1];
             resultBoolean = isValidDayOfWeek(dayString);
@@ -118,6 +90,6 @@ public class Shift {
             return false;
         }
         Shift otherShift = (Shift) other;
-        return toString().equals(otherShift.toString());
+        return slot.equals(otherShift.slot) && dayOfWeek.equals(otherShift.dayOfWeek);
     }
 }

--- a/src/main/java/seedu/address/model/person/Slot.java
+++ b/src/main/java/seedu/address/model/person/Slot.java
@@ -47,6 +47,19 @@ public enum Slot {
         for (Slot s : Slot.values()) {
             if (s.getValue().equalsIgnoreCase(trimmedString)) {
                 resultSlot = s;
+                break;
+            }
+        }
+        return resultSlot;
+    }
+
+    public static Slot getSlotByOrder(String string) {
+        String trimmedString = string.trim();
+        Slot resultSlot = null;
+        for (Slot s : Slot.values()) {
+            if (String.valueOf(s.getOrder()).equals(trimmedString)) {
+                resultSlot = s;
+                break;
             }
         }
         return resultSlot;

--- a/src/main/java/seedu/address/model/person/Slot.java
+++ b/src/main/java/seedu/address/model/person/Slot.java
@@ -6,6 +6,9 @@ package seedu.address.model.person;
 public enum Slot {
     MORNING("morning", 0), AFTERNOON("afternoon", 1);
 
+    public static final String MESSAGE_CONSTRAINTS =
+            "List of valid slots: morning, afternoon.";
+
     private String period;
     private int order;
 
@@ -58,7 +61,7 @@ public enum Slot {
     public static boolean isValidSlot(String test) {
         String trimmedTest = test.trim();
         for (Slot s : Slot.values()) {
-            String sString = String.valueOf(s.getOrder());
+            String sString = String.valueOf(s.getValue());
             if (sString.equals(trimmedTest)) {
                 return true;
             }

--- a/src/main/java/seedu/address/model/person/exceptions/DuplicateShiftException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/DuplicateShiftException.java
@@ -1,4 +1,10 @@
 package seedu.address.model.person.exceptions;
 
-public class DuplicateShiftException extends Exception{
+/**
+ * Represents an error caused by user wants to add a duplicate shift inside a staff's schedule.
+ */
+public class DuplicateShiftException extends RuntimeException {
+    public DuplicateShiftException() {
+        super("Operation would result in duplicate shift for a staff.");
+    }
 }

--- a/src/main/java/seedu/address/model/person/exceptions/DuplicateShiftException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/DuplicateShiftException.java
@@ -1,0 +1,4 @@
+package seedu.address.model.person.exceptions;
+
+public class DuplicateShiftException extends Exception{
+}

--- a/src/main/java/seedu/address/model/person/exceptions/InvalidTimeException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/InvalidTimeException.java
@@ -1,4 +1,0 @@
-package seedu.address.model.person.exceptions;
-
-public class InvalidTimeException extends Exception{
-}

--- a/src/main/java/seedu/address/model/person/exceptions/OverlapTaskException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/OverlapTaskException.java
@@ -1,4 +1,0 @@
-package seedu.address.model.person.exceptions;
-
-public class OverlapTaskException extends Exception{
-}

--- a/src/main/java/seedu/address/model/person/exceptions/PersonNotFoundException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/PersonNotFoundException.java
@@ -1,6 +1,10 @@
 package seedu.address.model.person.exceptions;
 
 /**
- * Signals that the operation is unable to find the specified person.
+ * Signals that the operation is unable to find the specified staff in the address book.
  */
-public class PersonNotFoundException extends RuntimeException {}
+public class PersonNotFoundException extends RuntimeException {
+    public PersonNotFoundException() {
+        super("Target person does not exist in the address book.");
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -150,19 +150,20 @@ class JsonAdaptedPerson {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     Schedule.class.getSimpleName()));
         }
-        if (!Schedule.isValidSchedule(schedule)) {
+
+        if (!Schedule.isValidSchedule(schedule.trim())) {
             throw new IllegalValueException(Schedule.MESSAGE_CONSTRAINTS);
         }
         Schedule modelSchedule;
-        if (schedule.equals("")) {
+        if (schedule.trim().equals("")) {
             modelSchedule = new Schedule();
         } else {
-            modelSchedule = new Schedule(schedule);
-            //modelSchedule = new Schedule();
+            modelSchedule = new Schedule(schedule.trim());
         }
-        return new Person(modelName, modelPhone, modelEmail,
+        Person p = new Person(modelName, modelPhone, modelEmail,
                 modelAddress, modelRole, modelSalary, modelStatus, modelTags);
-        // editStaff implementer: todo is there a way for you to edit schedule of this person to have modelSchedule
+        p.setSchedule(modelSchedule);
+        return p;
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -157,7 +157,8 @@ class JsonAdaptedPerson {
         if (schedule.equals("")) {
             modelSchedule = new Schedule();
         } else {
-            modelSchedule = new Schedule(schedule);
+//            modelSchedule = new Schedule(schedule);
+            modelSchedule = new Schedule();
         }
         return new Person(modelName, modelPhone, modelEmail,
                 modelAddress, modelRole, modelSalary, modelStatus, modelTags);

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -157,7 +157,7 @@ class JsonAdaptedPerson {
         if (schedule.equals("")) {
             modelSchedule = new Schedule();
         } else {
-//            modelSchedule = new Schedule(schedule);
+            //modelSchedule = new Schedule(schedule);
             modelSchedule = new Schedule();
         }
         return new Person(modelName, modelPhone, modelEmail,

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -157,8 +157,8 @@ class JsonAdaptedPerson {
         if (schedule.equals("")) {
             modelSchedule = new Schedule();
         } else {
-            //modelSchedule = new Schedule(schedule);
-            modelSchedule = new Schedule();
+            modelSchedule = new Schedule(schedule);
+            //modelSchedule = new Schedule();
         }
         return new Person(modelName, modelPhone, modelEmail,
                 modelAddress, modelRole, modelSalary, modelStatus, modelTags);

--- a/src/test/java/seedu/address/model/person/ScheduleTest.java
+++ b/src/test/java/seedu/address/model/person/ScheduleTest.java
@@ -29,7 +29,7 @@ public class ScheduleTest {
         assertFalse(Schedule.isValidSchedule("abcde")); // invalid string
 
         // valid addresses
-        assertTrue(Schedule.isValidSchedule("monday-0- tuesday-1-closingshift"));
+        assertTrue(Schedule.isValidSchedule("monday-morning tuesday-afternoon"));
         assertTrue(Schedule.isValidSchedule("")); //empty schedule
     }
 }

--- a/src/test/java/seedu/address/stubs/model/ModelStub.java
+++ b/src/test/java/seedu/address/stubs/model/ModelStub.java
@@ -9,6 +9,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Slot;
 import seedu.address.model.person.exceptions.DuplicateShiftException;
@@ -80,6 +81,11 @@ public class ModelStub implements Model {
     @Override
     public void setPerson(Person target, Person editedPerson) {
         throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Person findPersonByName(Name name) {
+        throw new AssertionError("This method should not be called");
     }
 
     @Override

--- a/src/test/java/seedu/address/stubs/model/ModelStub.java
+++ b/src/test/java/seedu/address/stubs/model/ModelStub.java
@@ -1,6 +1,7 @@
 package seedu.address.stubs.model;
 
 import java.nio.file.Path;
+import java.time.DayOfWeek;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -9,6 +10,8 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Slot;
+import seedu.address.model.person.exceptions.DuplicateShiftException;
 
 /**
  * A default model stub that have all of the methods failing.
@@ -67,6 +70,11 @@ public class ModelStub implements Model {
     @Override
     public void deletePerson(Person target) {
         throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addShift(Person target, DayOfWeek dayOfWeek, Slot slot) throws DuplicateShiftException {
+        throw new AssertionError("This method should not be called");
     }
 
     @Override


### PR DESCRIPTION
This PR consists of adding functionality for users to add a shift to a staff.

<del>format of the command: addShift 1 sl/morning d/monday </del>
format:
addShift n/name d/fullDayName-slotNumber
addShift i/index d/fullDayName-shiftNumber

e.g.
addShift n/Outong d/monday-1
addShift i/3 d/TUesday-1



notes:
<del>It seems like In the JsonAdaptedPerson.java, if you keep line 160. then after you modify one staff's schedule, next time when you run the code a NullPointerException() will be thrown. </del>
- fullDayName is not case sensitive
- cannot use tag n and i at the same time

todos:
- [ ] Write test classes
- [X] Type (/t) is not included in the command yet (decide to remove it)
- [X] Make message conveyed to users more specific
- [x] Make the exception created for schedule and shift more specific (Right now it just contain name)
- [X] Find out the reason why the above problem exists
- [x] Might change the command name from addSchedule to addShift in the UG?

Closes #8 